### PR TITLE
metadata: remove app.yaml version

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -18,11 +18,6 @@ readme: |
  * Controllers to provision these resources in a Rook Kubernetes cluster based on the users desired state captured in CRDs they create
  * Implementations of Crossplane's [portable resource abstractions](https://crossplane.io/docs/master/running-resources.html), enabling Rook resources to fulfill a user's general need for cloud services
 
-# Version of project (optional)
-# If omitted the version will be filled with the docker tag
-# If set it must match the docker tag
-version: 0.0.1
-
 # Maintainer names and emails.
 maintainers:
 - name: Jared Watts


### PR DESCRIPTION
### Overview

We have observed that we appear to be treating stack version as having
two sources of truth: the app.yaml, and the docker tag. We plan to move
away from using the version in `app.yaml` as part of making it simpler
to manage the versions for our stacks.

### Testing done

I have tested this locally, and we will need https://github.com/crossplane/crossplane/issues/1307 to be done before we can merge this.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/stack-gcp/blob/master/config/stack/manifests/app.yaml